### PR TITLE
Informar cobertura en PRs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,4 +29,8 @@ jobs:
     steps:
       - name: Run black formatter
         uses: rickstaa/action-black@v1.3.3
+
+      - name: Pytest Coverage Commentator
+        uses: coroo/pytest-coverage-commentator@v1.0.2
+            
             


### PR DESCRIPTION
Se agregó la información de cobertura en PRs, agregando:
- name: Pytest Coverage Commentator
   uses: coroo/pytest-coverage-commentator@v1.0.2
A steps de format, en el archivo .github/workflows/main.yml